### PR TITLE
Change 'attribute' field within Correlations to STRING

### DIFF
--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,5 +6,5 @@ EXPORT Bundle := MODULE(Std.BundleBase)
     EXPORT License := 'http://www.apache.org/licenses/LICENSE-2.0';
     EXPORT Copyright := 'Copyright (C) 2018 HPCC Systems';
     EXPORT DependsOn := [];
-    EXPORT Version := '1.0.1';
+    EXPORT Version := '1.0.2';
 END;

--- a/Profile.ecl
+++ b/Profile.ecl
@@ -901,7 +901,7 @@ EXPORT Profile(inFile,
     END;
 
     LOCAL CorrelationRec := RECORD
-        Attribute_t                 attribute;
+        STRING                      attribute;
         DECIMAL7_6                  corr;
     END;
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ level, such as within your "My Files" folder.
 |:----:|:-----|
 |1.0.0|Initial public release, finally with support for datasets defined using dynamic record lookup|
 |1.0.1|Add `ProfileFromPath` and `BestRecordStructureFromPath`; ave\_length bug fix|
+|1.0.2|Change attribute field in CorrelationsRec embedded dataset to STRING|
 
 
 ### Profile


### PR DESCRIPTION
This results in a more general-purpose record structure for the output.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>