### PR TITLE
Examine UTF8 values for best attribute type

### DIFF
--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,5 +6,5 @@ EXPORT Bundle := MODULE(Std.BundleBase)
     EXPORT License := 'http://www.apache.org/licenses/LICENSE-2.0';
     EXPORT Copyright := 'Copyright (C) 2019 HPCC Systems';
     EXPORT DependsOn := [];
-    EXPORT Version := '1.1.0';
+    EXPORT Version := '1.1.1';
 END;

--- a/Profile.ecl
+++ b/Profile.ecl
@@ -554,13 +554,13 @@ EXPORT Profile(inFile,
                     AttributeTypeRec,
                     SELF.best_attribute_type := MAP
                         (
-                            REGEXFIND('(decimal)|(boolean)|(utf)', LEFT.given_attribute_type)   =>  LEFT.given_attribute_type,
+                            REGEXFIND('(decimal)|(boolean)', LEFT.given_attribute_type)         =>  LEFT.given_attribute_type,
                             REGEXFIND('data', LEFT.given_attribute_type)                        =>  'data' + IF(LEFT.data_length > 0, (STRING)LEFT.data_length, ''),
                             (LEFT.type_flag & DataTypeEnum.UnsignedInteger) != 0                =>  'unsigned' + Len2Size(LEFT.data_length),
                             (LEFT.type_flag & DataTypeEnum.SignedInteger) != 0                  =>  'integer' + Len2Size(LEFT.data_length),
                             (LEFT.type_flag & DataTypeEnum.FloatingPoint) != 0                  =>  'real' + IF(LEFT.data_length < 8, '4', '8'),
                             (LEFT.type_flag & DataTypeEnum.ExpNotation) != 0                    =>  'real8',
-                            REGEXFIND('(real)', LEFT.given_attribute_type)                      =>  LEFT.given_attribute_type,
+                            REGEXFIND('(utf)|(real)', LEFT.given_attribute_type)                =>  LEFT.given_attribute_type,
                             REGEXREPLACE('\\d+$', TRIM(LEFT.given_attribute_type), '') + IF(LEFT.data_length > 0, (STRING)LEFT.data_length, '')
                         ),
                     SELF := LEFT

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ level, such as within your "My Files" folder.
 |1.0.1|Add `ProfileFromPath` and `BestRecordStructureFromPath`; ave\_length bug fix|
 |1.0.2|Change attribute field in CorrelationsRec embedded dataset to STRING|
 |1.1.0|Add record count breakdown for low-cardinality field values; ProfileFromPath() returns correct record structure|
+|1.1.1|Examine UTF8 values for alternate best\_attribute\_type data types rather than just passing them through|
 
 
 ### Profile


### PR DESCRIPTION
Previously, the best_attribute_type result from UTF8 fields was simply UTF8.  With this change, the data patterns within UTF8 fields are parsed and a best_attribute_type recommendation is based on the findings (as it does for other types, such as STRING).

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>