### PR TITLE
Bug fix: Support just-sprayed CSV files

### DIFF
--- a/BestRecordStructureFromPath.ecl
+++ b/BestRecordStructureFromPath.ecl
@@ -85,13 +85,12 @@ EXPORT BestRecordStructureFromPath(path, sampling = 100, emitTransform = FALSE) 
             );
     ENDMACRO;
 
-    fileKind2 := WHEN(fileKind, OUTPUT(fileKind, NAMED('fileKind')));
-
     LOCAL resultStructure := CASE
         (
-            fileKind2,
+            TRIM(fileKind, ALL),
             'flat'  =>  RunBestRecordStructure(flatDataset, sampling, emitTransform),
             'csv'   =>  RunBestRecordStructure(csvDataset, sampling, emitTransform),
+            ''      =>  RunBestRecordStructure(csvDataset, sampling, emitTransform),
             ERROR(DATASET([], CommonResultRec), 'Cannot run BestRecordStructure on file of kind "' + fileKind + '"')
         );
 

--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,5 +6,5 @@ EXPORT Bundle := MODULE(Std.BundleBase)
     EXPORT License := 'http://www.apache.org/licenses/LICENSE-2.0';
     EXPORT Copyright := 'Copyright (C) 2019 HPCC Systems';
     EXPORT DependsOn := [];
-    EXPORT Version := '1.2.0';
+    EXPORT Version := '1.2.1';
 END;

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ level, such as within your "My Files" folder.
 |1.1.0|Add record count breakdown for low-cardinality field values; ProfileFromPath() returns correct record structure|
 |1.1.1|Examine UTF8 values for alternate best\_attribute\_type data types rather than just passing them through|
 |1.2.0|Add option to emit a suitable TRANSFORM function to BestRecordStructure and BestRecordStructureFromPath|
+|1.2.1|Just-sprayed CSV files now supported within BestRecordStructureFromPath|
 
 
 ### Profile


### PR DESCRIPTION
The content type is not set for just sprayed-CSV files, so assume that those files are CSV-formatted.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>