### PR TITLE
Issue-34 BestRecordStructure: Fix output order of items when TRANSFORM is included

### DIFF
--- a/BestRecordStructure.ecl
+++ b/BestRecordStructure.ecl
@@ -265,7 +265,7 @@ EXPORT BestRecordStructure(inFile, sampling = 100, emitTransform = FALSE, textOu
 
     // Create the top-level record definition
     LOCAL topLevel := DATASET(['NewLayout := RECORD'], OutRec)
-        + PROJECT
+        & PROJECT
             (
                 SORT(fieldInfo6, position),
                 TRANSFORM
@@ -274,7 +274,7 @@ EXPORT BestRecordStructure(inFile, sampling = 100, emitTransform = FALSE, textOu
                         SELF.s := '    ' + IF(Std.Str.Contains(LEFT.bestAttributeType, '{', FALSE), LEFT.bestAttributeType, Std.Str.ToUpperCase(LEFT.bestAttributeType)) + ' ' + LEFT.name + ';'
                     )
             )
-        + DATASET(['END;'], OutRec);
+        & DATASET(['END;'], OutRec);
 
     // Final output includes the named child records and the top-level record
     // definition we just built
@@ -341,7 +341,7 @@ EXPORT BestRecordStructure(inFile, sampling = 100, emitTransform = FALSE, textOu
         );
 
     // Combine optional transform
-    LOCAL allOutput := layoutRes + DATASET(transformSet, OutRec);
+    LOCAL allOutput := layoutRes & DATASET(transformSet, OutRec);
 
     // Roll everything up to one string with HTML line breaks
     LOCAL htmlString := ROLLUP

--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,5 +6,5 @@ EXPORT Bundle := MODULE(Std.BundleBase)
     EXPORT License := 'http://www.apache.org/licenses/LICENSE-2.0';
     EXPORT Copyright := 'Copyright (C) 2019 HPCC Systems';
     EXPORT DependsOn := [];
-    EXPORT Version := '1.3.4';
+    EXPORT Version := '1.3.5';
 END;

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ level, such as within your "My Files" folder.
 |1.3.2|Allow most CSV attributes to acquire default values in ProfileFromPath and BestRecordStructureFromPath|
 |1.3.3|Add file kind gathering back to the code in ProfileFromPath and BestRecordStructureFromPath (regression from 1.3.2)|
 |1.3.4|When given explicit numeric attribute types, refrain from recommending a "best" attribute type|
+|1.3.5|Fix ordering of output in BestRecordStructure when TRANSFORM is emitted|
 
 
 ### Profile


### PR DESCRIPTION
Use & operator to concatenate interim datasets to enforce correct ordering.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>