### PR TITLE
Candidate 1.4.2

### DIFF
--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,5 +6,5 @@ EXPORT Bundle := MODULE(Std.BundleBase)
     EXPORT License := 'http://www.apache.org/licenses/LICENSE-2.0';
     EXPORT Copyright := 'Copyright (C) 2019 HPCC Systems';
     EXPORT DependsOn := [];
-    EXPORT Version := '1.4.1';
+    EXPORT Version := '1.4.2';
 END;

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ level, such as within your "My Files" folder.
 |1.3.5|Fix ordering of output in BestRecordStructure when TRANSFORM is emitted|
 |1.4.0|Automatically include improved visual results of Profile, including data distribution graphs (within workunit's Resources tab)|
 |1.4.1|Regression: Fix self-tests that were failing due to changes in v1.3.4|
-|1.4.2|Strings fields containing all numerics with leading zeros are now marked as string in best\_attribute\_type|
+|1.4.2|String fields containing all numerics with leading zeros are now marked as string in best\_attribute\_type; string fields where the length varies by more than three orders of magnitude are now marked as string in best\_attribute\_type|
 
 <a name="profile"></a>
 ### Profile

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ level, such as within your "My Files" folder.
 |1.3.5|Fix ordering of output in BestRecordStructure when TRANSFORM is emitted|
 |1.4.0|Automatically include improved visual results of Profile, including data distribution graphs (within workunit's Resources tab)|
 |1.4.1|Regression: Fix self-tests that were failing due to changes in v1.3.4|
+|1.4.2|Strings fields containing all numerics with leading zeros are now marked as string in best\_attribute\_type|
 
 <a name="profile"></a>
 ### Profile

--- a/Tests.ecl
+++ b/Tests.ecl
@@ -474,4 +474,29 @@ EXPORT Tests := MODULE
             ASSERT(COUNT(Embedded_Child1_Profile(attribute = 'foo.z')[1].numeric_correlations) = 2),
             ASSERT(TRUE)
         ];
+
+    //--------------------------------------------------------------------------
+    // Test strings fields containing numerics with leading zeros (issue 42)
+    //--------------------------------------------------------------------------
+
+    SHARED Leading_Zeros := DATASET
+        (
+            [
+                {'0100', '1234', '0001', '7809', '-0600'},
+                {'0020', '0001', '0023', '0001', '600'}
+            ],
+            {STRING s1, STRING s2, STRING s3, STRING s4, STRING s5}
+        );
+
+    SHARED Leading_Zeros_Profile := DataPatterns.Profile(NOFOLD(Leading_Zeros), features := 'best_ecl_types');
+
+    EXPORT Test_Leading_Zeros_Profile :=
+        [
+            ASSERT(ValueForAttr(Leading_Zeros_Profile, 's1', best_attribute_type) = 'string4'),
+            ASSERT(ValueForAttr(Leading_Zeros_Profile, 's2', best_attribute_type) = 'string4'),
+            ASSERT(ValueForAttr(Leading_Zeros_Profile, 's3', best_attribute_type) = 'string4'),
+            ASSERT(ValueForAttr(Leading_Zeros_Profile, 's4', best_attribute_type) = 'string4'),
+            ASSERT(ValueForAttr(Leading_Zeros_Profile, 's5', best_attribute_type) = 'integer3'),
+            ASSERT(TRUE)
+        ];
 END;


### PR DESCRIPTION
issue-42 All-numeric string fields containing leading zeros should be left as string types

issue-46 Mark string fields with wildly-varying lengths as 'string' in best data types